### PR TITLE
DESIRE coin (DSR): masternode payments enabled

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -207,6 +207,7 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		strcmp(coind->symbol, "MUE") == 0 || // MUEcore-x11
 		strcmp(coind->symbol, "VIVO") == 0 || // VIVO coin
 	   	strcmp(coind->symbol, "INN") == 0 || // Innova coin
+	   	strcmp(coind->symbol, "DSR") == 0 || // Desire coin
 		strcmp(coind->symbol, "DASH") == 0 || strcmp(coind->symbol, "DASH-TESTNET") == 0) // Dash 12.1
 	{
 		char script_dests[2048] = { 0 };


### PR DESCRIPTION
https://bitcointalk.org/index.php?topic=2272607.msg23083239#msg23083239

Masternode payments enabled.

getblocktemplate:
"masternode": {
"payee": "D5rbtUcYuyDPdFpotGBvzoGjt9z81QoKpj",
"script": "76a91407d98dac0453c81cc78e7b0c834a574894d1afc388ac",
"amount": 500001496
},
"masternode_payments_started": true,
"masternode_payments_enforced": true,

so, should be new version (like on Dash 12.1)

coinbase.cpp (stratum on yiimp)

  strcmp(coind->symbol, "DASH") == 0 || strcmp(coind->symbol, "DASH-TESTNET") == 0) // Dash 12.1

-------
Ticker is DSR:
http://coinsmarkets.com/trade-BTC-DSR.htm